### PR TITLE
Add graphviz requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Example:
 
 ## Installation
 
+Install [`graphviz`](https://graphviz.org/download/) for your operating system.
+
 Check out this repository and run:
 
 ```


### PR DESCRIPTION
I ran into the following error trying to use the app: 

```
`dot` not installed on this machine
```

I had to install graphviz to get `dot`, so here's a PR to add that installation requirement. 